### PR TITLE
fix call to girafe in progressive_packing.Rmd

### DIFF
--- a/vignettes/progressive_packing.Rmd
+++ b/vignettes/progressive_packing.Rmd
@@ -219,7 +219,7 @@ if (requireNamespace("ggiraph")) {
     
     coord_equal()
   
-  ggiraph::ggiraph(ggobj = gg, width_svg = 5, height_svg = 5)
+  ggiraph::girafe(ggobj = gg, width_svg = 5, height_svg = 5)
   
 }
 


### PR DESCRIPTION
Hello,

`ggiraph::ggiraph()` was deprecated since a long time but now it is defunct. This PR adapt your vignette code so that it uses `ggiraph::girafe()`